### PR TITLE
Apalaniuk/use cdn pdfjs

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,6 @@
     "d2l-localize-behavior": "^1.1.3",
     "d2l-typography": "^6.1.3",
     "d2l-video": "^2.0.2",
-    "pdfjs-dist": "^2.0.550",
     "polymer": "Polymer/polymer#1.9 - 2",
     "d2l-page-load-progress": "^2.2.0"
   },

--- a/d2l-pdf-viewer.html
+++ b/d2l-pdf-viewer.html
@@ -3,10 +3,10 @@
 <link rel="import" href="d2l-pdf-viewer-toolbar.html">
 
 <!-- @note: aware that external stylesheets are very deprecated -->
-<link rel="stylesheet" href="../pdfjs-dist/web/pdf_viewer.css">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.0.943/pdf_viewer.css">
 
-<script src="../pdfjs-dist/build/pdf.js"></script>
-<script src="../pdfjs-dist/web/pdf_viewer.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.0.943/pdf.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.0.943/pdf_viewer.js"></script>
 
 <dom-module id="d2l-pdf-viewer">
 	<template strip-whitespace>
@@ -69,12 +69,6 @@
 					type: String,
 					observer: '_srcChanged'
 				},
-				workerSrc: {
-					type: String,
-					value: () => {
-						this.importPath + '../pdfjs-dist/build/pdf.worker.min.js';
-					}
-				},
 				_pageLabel: {
 					type: String,
 					value: null
@@ -102,7 +96,8 @@
 				}
 			},
 			ready: function() {
-				pdfjsLib.GlobalWorkerOptions.workerSrc = this.workerSrc;
+				pdfjsLib.GlobalWorkerOptions.workerSrc =
+					'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.0.943/pdf.worker.min.js';
 
 				// (Optionally) enable hyperlinks within PDF files.
 				var pdfLinkService = new pdfjsViewer.PDFLinkService();


### PR DESCRIPTION
Thrashing, but: consumer is quite.. obtuse, and difficult to verify whether pdf.js worker is being bundled correctly. Use CDN for now.