### PR TITLE
pdf-viewer: loadingTask.then is deprecated on pdf.js master

### DIFF
--- a/d2l-pdf-viewer.html
+++ b/d2l-pdf-viewer.html
@@ -178,7 +178,7 @@
 					this.$.progressBar.value = (progressData.loaded / progressData.total) * 100;
 				};
 
-				loadingTask.then(pdfDocument => {
+				loadingTask.promise.then(pdfDocument => {
 					let pdfName = '';
 					const parts = this.src.split('/');
 


### PR DESCRIPTION
Version in use:
https://github.com/mozilla/pdf.js/blob/v2.0.943/src/display/api.js#L508-L510

Current master:
https://github.com/mozilla/pdf.js/blob/1cb7cc9bf406818ca44b02aa8e6b36074ddae77a/src/display/api.js#L502-L506