### PR TITLE
Fix wonky CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,1 @@
-*       @ifun
-*		@apalaniuk
-*		@chriskraljevicd2l
+* @ifun @apalaniuk @chriskraljevicd2l


### PR DESCRIPTION
Only @ChrisKraljevicD2L was being added as a code owner because the global owners list was being overwritten on each line