### PR TITLE
Use indeterminate progress bar if total unavailable/load PDF on property change

### DIFF
--- a/d2l-pdf-viewer-progress-bar.html
+++ b/d2l-pdf-viewer-progress-bar.html
@@ -181,7 +181,7 @@ Polymer-based web component progress bar
 
 				_onTransitionEndEvent: function() {
 					if (this._progress === 100) {
-						// Ensure it stays visible for a moment in case eg. consumer is hiding on completion
+						// Delay for a moment in case eg. consumer is using event to hide on completion
 						setTimeout(function() {
 							this.dispatchEvent(new CustomEvent('d2l-pdf-viewer-progress-bar-animation-complete'));
 						}.bind(this), 200);

--- a/d2l-pdf-viewer.html
+++ b/d2l-pdf-viewer.html
@@ -256,11 +256,11 @@
 					progressBar.indeterminate = false;
 					progressBar.hidden = false;
 
-					this._loadingTask = pdfjsLib.getDocument({
+					const loadingTask = this._loadingTask = pdfjsLib.getDocument({
 						url: src
 					});
 
-					this._loadingTask.onProgress = (progressData) => {
+					loadingTask.onProgress = (progressData) => {
 						if (progressData.total && !progressBar.indeterminate) {
 							progressBar.value = progressData.loaded / progressData.total;
 						} else if (!progressBar.indeterminate) {
@@ -268,13 +268,18 @@
 						}
 					};
 
-					this._loadingTask.then(pdfDocument => {
+					loadingTask.then(pdfDocument => {
 						this._pdfViewer.setDocument(pdfDocument);
 						this._pagesCount = pdfDocument.numPages;
 						this._pageNumber = this._pdfViewer.currentPageNumber;
 
 						this._pdfLinkService.setDocument(pdfDocument, null);
 					}).catch(() => {
+						if (loadingTask.destroyed) {
+							// the load was canceled because the src changed
+							return;
+						}
+
 						this.dispatchEvent(new CustomEvent('d2l-pdf-viewer-load-failed', {
 							bubbles: true,
 							composed: true

--- a/d2l-pdf-viewer.html
+++ b/d2l-pdf-viewer.html
@@ -156,48 +156,19 @@
 					'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.0.943/pdf.worker.min.js';
 
 				// (Optionally) enable hyperlinks within PDF files.
-				var pdfLinkService = new pdfjsViewer.PDFLinkService({
+				this._pdfLinkService = new pdfjsViewer.PDFLinkService({
 					externalLinkTarget: pdfjsLib.LinkTarget.BLANK
 				});
 
 				this._pdfViewer = new pdfjsViewer.PDFViewer({
 					container: this.$.viewerContainer,
-					linkService: pdfLinkService
+					linkService: this._pdfLinkService
 				});
 
-				pdfLinkService.setViewer(this._pdfViewer);
+				this._pdfLinkService.setViewer(this._pdfViewer);
 
 				// Add event listeners before loading document
 				this._addEventListeners();
-
-				const loadingTask = pdfjsLib.getDocument({
-					url: this.src
-				});
-
-				loadingTask.onProgress = (progressData) => {
-					this.$.progressBar.value = (progressData.loaded / progressData.total) * 100;
-				};
-
-				loadingTask.promise.then(pdfDocument => {
-					let pdfName = '';
-					const parts = this.src.split('/');
-
-					if (parts.length > 0) {
-						pdfName = parts[parts.length - 1];
-					}
-
-					this._pdfName = pdfName;
-					this._pdfViewer.setDocument(pdfDocument);
-					this._pagesCount = pdfDocument.numPages;
-					this._pageNumber = this._pdfViewer.currentPageNumber;
-
-					pdfLinkService.setDocument(pdfDocument, null);
-				}).catch(() => {
-					this.dispatchEvent(new CustomEvent('d2l-pdf-viewer-load-failed', {
-						bubbles: true,
-						composed: true
-					}));
-				});
 			},
 			detached: function() {
 				window.removeEventListener('resize', this._resize);
@@ -259,15 +230,67 @@
 					}, 100);
 				}
 			},
-			_srcChanged: function() {
-				this.$.progressBar.value = 0;
-				this.$.progressBar.hidden = false;
+			_srcChanged: function(src) {
+				const progressBar = this.$.progressBar;
+				let destroyLoadingTask = Promise.resolve();
+				let pdfName = '';
+
+				if (this._loadingTask) {
+					destroyLoadingTask = this._loadingTask.destroy();
+					this._loadingTask = null;
+				}
+
+				if (!src) {
+					return;
+				}
+
+				const parts = src.split('/');
+
+				if (parts.length > 0) {
+					pdfName = parts[parts.length - 1];
+				}
+
+				this._pdfName = pdfName;
+
+				destroyLoadingTask.then(() => {
+					progressBar.indeterminate = false;
+					progressBar.hidden = false;
+
+					this._loadingTask = pdfjsLib.getDocument({
+						url: src
+					});
+
+					this._loadingTask.onProgress = (progressData) => {
+						if (progressData.total && !progressBar.indeterminate) {
+							progressBar.value = progressData.loaded / progressData.total;
+						} else if (!progressBar.indeterminate) {
+							progressBar.indeterminate = true;
+						}
+					};
+
+					this._loadingTask.then(pdfDocument => {
+						this._pdfViewer.setDocument(pdfDocument);
+						this._pagesCount = pdfDocument.numPages;
+						this._pageNumber = this._pdfViewer.currentPageNumber;
+
+						this._pdfLinkService.setDocument(pdfDocument, null);
+					}).catch(() => {
+						this.dispatchEvent(new CustomEvent('d2l-pdf-viewer-load-failed', {
+							bubbles: true,
+							composed: true
+						}));
+					});
+				});
 			},
 			_onPagesInitEvent: function() {
 				this._pdfViewer.currentScaleValue = 'page-width';
 				this._pageScale = this._pdfViewer.currentScale;
 				this._onInteraction();
 				this._isLoaded = true;
+
+				if (this.$.progressBar.indeterminate) {
+					this.$.progressBar.finish();
+				}
 			},
 			_onPageChangeEvent: function(evt) {
 				this._pageNumber = evt.pageNumber;

--- a/d2l-pdf-viewer.html
+++ b/d2l-pdf-viewer.html
@@ -106,8 +106,7 @@
 					value: 5
 				},
 				src: {
-					type: String,
-					observer: '_srcChanged'
+					type: String
 				},
 				_isFullscreen: {
 					type: Boolean,
@@ -135,7 +134,8 @@
 					type: Number
 				},
 				_pdfName: {
-					type: String
+					type: String,
+					value: ''
 				},
 				_showToolbar: {
 					type: Boolean,
@@ -151,6 +151,9 @@
 				'focusin': '_onInteraction',
 				'focusout': '_onFocusOut'
 			},
+			observers: [
+				'_srcChanged(isAttached, src)'
+			],
 			ready: function() {
 				pdfjsLib.GlobalWorkerOptions.workerSrc =
 					'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.0.943/pdf.worker.min.js';
@@ -230,10 +233,19 @@
 					}, 100);
 				}
 			},
-			_srcChanged: function(src) {
+			_srcChanged: function(isAttached, src) {
+				if (!isAttached) {
+					return;
+				}
+
 				const progressBar = this.$.progressBar;
 				let destroyLoadingTask = Promise.resolve();
 				let pdfName = '';
+
+				this._resetPdfData();
+
+				progressBar.indeterminate = false;
+				progressBar.value = 0;
 
 				if (this._loadingTask) {
 					destroyLoadingTask = this._loadingTask.destroy();
@@ -253,28 +265,35 @@
 				this._pdfName = pdfName;
 
 				destroyLoadingTask.then(() => {
-					progressBar.indeterminate = false;
-					progressBar.hidden = false;
-
 					const loadingTask = this._loadingTask = pdfjsLib.getDocument({
 						url: src
 					});
 
+					progressBar.hidden = false;
+
 					loadingTask.onProgress = (progressData) => {
-						if (progressData.total && !progressBar.indeterminate) {
-							progressBar.value = progressData.loaded / progressData.total;
-						} else if (!progressBar.indeterminate) {
-							progressBar.indeterminate = true;
+						if (progressBar.indeterminate) {
+							return;
 						}
+
+						if (!progressData.total) {
+							progressBar.indeterminate = true;
+							progressBar.start();
+							return;
+						}
+
+						progressBar.value = progressData.loaded / progressData.total;
 					};
 
-					loadingTask.then(pdfDocument => {
+					loadingTask.promise.then(pdfDocument => {
 						this._pdfViewer.setDocument(pdfDocument);
 						this._pagesCount = pdfDocument.numPages;
 						this._pageNumber = this._pdfViewer.currentPageNumber;
 
 						this._pdfLinkService.setDocument(pdfDocument, null);
 					}).catch(() => {
+						progressBar.hidden = true;
+
 						if (loadingTask.destroyed) {
 							// the load was canceled because the src changed
 							return;
@@ -389,6 +408,14 @@
 			},
 			_computeShowToolbar: function(isLoaded, hasRecentInteraction) {
 				return !!isLoaded && !!hasRecentInteraction;
+			},
+			_resetPdfData: function() {
+				this._pdfViewer.setDocument(null);
+				this._pdfLinkService.setDocument(null);
+				this._pageNumber = 0;
+				this._pagesCount = 0;
+				this._isLoaded = false;
+				this._pdfName = '';
 			}
 		});
 	</script>

--- a/d2l-pdf-viewer.html
+++ b/d2l-pdf-viewer.html
@@ -234,13 +234,12 @@
 				}
 			},
 			_srcChanged: function(isAttached, src) {
-				if (!isAttached) {
+				if (!isAttached || !src) {
 					return;
 				}
 
 				const progressBar = this.$.progressBar;
 				let destroyLoadingTask = Promise.resolve();
-				let pdfName = '';
 
 				this._resetPdfData();
 
@@ -252,17 +251,7 @@
 					this._loadingTask = null;
 				}
 
-				if (!src) {
-					return;
-				}
-
-				const parts = src.split('/');
-
-				if (parts.length > 0) {
-					pdfName = parts[parts.length - 1];
-				}
-
-				this._pdfName = pdfName;
+				this._setPdfNameFromUrl(src);
 
 				destroyLoadingTask.then(() => {
 					const loadingTask = this._loadingTask = pdfjsLib.getDocument({
@@ -416,6 +405,21 @@
 				this._pagesCount = 0;
 				this._isLoaded = false;
 				this._pdfName = '';
+			},
+			_setPdfNameFromUrl: function(src) {
+				if (!src) {
+					this._pdfName = '';
+					return;
+				}
+
+				const parts = src.split('/');
+				let pdfName = '';
+
+				if (parts.length > 0) {
+					pdfName = parts[parts.length - 1];
+				}
+
+				this._pdfName = pdfName;
 			}
 		});
 	</script>

--- a/test/d2l-pdf-viewer.html
+++ b/test/d2l-pdf-viewer.html
@@ -97,7 +97,12 @@
 							});
 
 							expect(pdfViewer.$.progressBar.indeterminate).to.be.true;
-							done();
+							expect(pdfViewer.$.progressBar._indeterminateState).to.equal(0); // RESET
+
+							setTimeout(() => {
+								expect(pdfViewer.$.progressBar._indeterminateState).to.equal(1); // IN_PROGRESS
+								done();
+							}, 100);
 						});
 					});
 				});

--- a/test/d2l-pdf-viewer.html
+++ b/test/d2l-pdf-viewer.html
@@ -1,0 +1,76 @@
+<html>
+	<head>
+		<meta charset="UTF-8">
+		<title>d2l pdf viewer toolbar basic tests</title>
+		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+		<script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+		<script src="../../web-component-tester/browser.js"></script>
+		<link rel="import" href="../d2l-pdf-viewer.html">
+	</head>
+	<body>
+		<test-fixture id="basic">
+			<template>
+				<d2l-pdf-viewer></d2l-pdf-viewer>
+			</template>
+		</test-fixture>
+		<script>
+			describe('<d2l-pdf-viewer>', function() {
+				let pdfViewer;
+				let pdfJsReal;
+
+				const PdfJsMock = function() {};
+
+				PdfJsMock.prototype = {
+					getDocument: function() {
+						return new Promise(() => {});
+					}
+				};
+
+				describe('loading', function() {
+					beforeEach(function() {
+						pdfViewer = fixture('basic');
+
+						pdfJsReal = pdfJsReal || window.pdfjsLib;
+
+						window.pdfjsLib = new PdfJsMock();
+					});
+
+					afterEach(function() {
+						window.pdfjsLib = pdfJsReal;
+					});
+
+					it('should report the determinate progress when available', function(done) {
+						pdfViewer.src = 'https://some.dummy.url/and-a-fake.pdf';
+
+						setTimeout(() => {
+							[0, 250, 500, 750, 1000].forEach(val => {
+								pdfViewer._loadingTask.onProgress({
+									loaded: val,
+									total: 1000
+								});
+
+								expect(pdfViewer.$.progressBar.indeterminate).to.be.false;
+								expect(pdfViewer.$.progressBar.value).to.equal(val / 1000);
+							});
+							done();
+						});
+					});
+
+					it('should use an indeterminate loading bar when total progress not available', function(done) {
+						pdfViewer.src = 'https://some.dummy.url/and-a-fake.pdf';
+
+						setTimeout(() => {
+							pdfViewer._loadingTask.onProgress({
+								loaded: 200,
+								total: undefined
+							});
+
+							expect(pdfViewer.$.progressBar.indeterminate).to.be.true;
+							done();
+						});
+					});
+				});
+			});
+		</script>
+	</body>
+</html>

--- a/test/d2l-pdf-viewer.html
+++ b/test/d2l-pdf-viewer.html
@@ -14,25 +14,40 @@
 			</template>
 		</test-fixture>
 		<script>
+			class PdfjsMock {
+				constructor(config = {}) {
+					this.__config = config;
+				}
+
+				getDocument(opts) {
+					return this.__config.loadingTasks[opts.url];
+				}
+			}
+
+			class LoadingTaskMock {
+				constructor(config = {}) {
+					this.__config = config;
+					this.__config.promise = this.__config.promise || new Promise(() => {});
+				}
+
+				get promise() {
+					return this.__config.promise;
+				}
+
+				destroy() {
+					return Promise.reject('Error: Worker was destroyed');
+				}
+			}
+
 			describe('<d2l-pdf-viewer>', function() {
 				let pdfViewer;
 				let pdfJsReal;
-
-				const PdfJsMock = function() {};
-
-				PdfJsMock.prototype = {
-					getDocument: function() {
-						return new Promise(() => {});
-					}
-				};
 
 				describe('loading', function() {
 					beforeEach(function() {
 						pdfViewer = fixture('basic');
 
 						pdfJsReal = pdfJsReal || window.pdfjsLib;
-
-						window.pdfjsLib = new PdfJsMock();
 					});
 
 					afterEach(function() {
@@ -40,11 +55,19 @@
 					});
 
 					it('should report the determinate progress when available', function(done) {
+						const loadingTaskMock = new LoadingTaskMock();
+
+						window.pdfjsLib = new PdfjsMock({
+							loadingTasks: {
+								'https://some.dummy.url/and-a-fake.pdf': loadingTaskMock
+							}
+						});
+
 						pdfViewer.src = 'https://some.dummy.url/and-a-fake.pdf';
 
 						setTimeout(() => {
 							[0, 250, 500, 750, 1000].forEach(val => {
-								pdfViewer._loadingTask.onProgress({
+								loadingTaskMock.onProgress({
 									loaded: val,
 									total: 1000
 								});
@@ -57,10 +80,18 @@
 					});
 
 					it('should use an indeterminate loading bar when total progress not available', function(done) {
+						const loadingTaskMock = new LoadingTaskMock();
+
+						window.pdfjsLib = new PdfjsMock({
+							loadingTasks: {
+								'https://some.dummy.url/and-a-fake.pdf': loadingTaskMock
+							}
+						});
+
 						pdfViewer.src = 'https://some.dummy.url/and-a-fake.pdf';
 
 						setTimeout(() => {
-							pdfViewer._loadingTask.onProgress({
+							loadingTaskMock.onProgress({
 								loaded: 200,
 								total: undefined
 							});

--- a/test/index.html
+++ b/test/index.html
@@ -15,7 +15,9 @@
 				'd2l-pdf-viewer-toolbar.html?wc-shadydom=true&wc-ce=true',
 				'd2l-pdf-viewer-toolbar.html?dom=shadow',
 				'd2l-pdf-viewer-progress-bar.html?wc-shadydom=true&wc-ce=true',
-				'd2l-pdf-viewer-progress-bar.html?dom=shadow'
+				'd2l-pdf-viewer-progress-bar.html?dom=shadow',
+				'd2l-pdf-viewer.html?wc-shadydom=true&wc-ce=true',
+				'd2l-pdf-viewer.html?dom=shadow'
 			]);
 		</script>
 	</body>


### PR DESCRIPTION
Think I got a little off-track here, so I can break this back up.

Original issue was I noticed in testing locally that retrieving content from the local content service that the progress bar wasn't working, as PDF.js couldn't infer the total size of the file. This doesn't fix that problem (which might not even exist on production?), but it seems reasonable to show a progress bar no matter what.

Also, moves loading to an observer on the source URL changing, and properly destroys the previous loading task.