### PR TITLE
Update artifactory URL

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,7 +1,7 @@
 {
 	"registry": {
 		"search": [
-			"https://ro-bower-d2l-file-viewer:mjQ63EVnKvAx2BL8tgUfmb_cX_Eh7w0CTKIYjcL0Ift1GC-dQuoNRNEC1i_mQwnjpPnBNqppDtprgtcfmuvbAg@d2lartifacts.artifactoryonline.com/d2lartifacts/api/bower/bower-local",
+			"https://ro-bower-d2l-file-viewer:mjQ63EVnKvAx2BL8tgUfmb_cX_Eh7w0CTKIYjcL0Ift1GC-dQuoNRNEC1i_mQwnjpPnBNqppDtprgtcfmuvbAg@d2lartifacts.jfrog.io/d2lartifacts/api/bower/bower-local",
 			"https://registry.bower.io"
 		]
 	},


### PR DESCRIPTION
Based on my understanding of the discussion in [this Slack thread](https://d2l.slack.com/archives/C1JSHPW91/p1548259489041000), we need to update the d2lartifact links in our NPMRC files to reflect the newer URL. This does that.